### PR TITLE
Adding in inline style fix for CSP errors

### DIFF
--- a/antiscroll.js
+++ b/antiscroll.js
@@ -451,16 +451,28 @@
 
   function scrollbarSize () {
     if (size === undefined) {
-      var div = $(
-          '<div class="antiscroll-inner" style="width:50px;height:50px;overflow-y:scroll;'
-        + 'position:absolute;top:-200px;left:-200px;"><div style="height:100px;width:100%"/>'
-        + '</div>'
-      );
+      var $div = $('<div class="antiscroll-inner"></div>');
+      var $innerDiv = $('<div />');
+      $div.css({
+        width: '50px',
+        height: '50px',
+        overflowY: 'scroll',
+        position: 'absolute',
+        top: '-200px',
+        left: '-200px',
+      });
+/*
+      $innerDiv.css({
+        height: '100px',
+        width: '100px'
+      });
+*/
+      $div.append($innerDiv);
 
-      $('body').append(div);
-      var w1 = $(div).innerWidth();
-      var w2 = $('div', div).innerWidth();
-      $(div).remove();
+      $('body').append($div);
+      var w1 = $div.innerWidth();
+      var w2 = $('div', $div).innerWidth();
+      $div.remove();
 
       size = w1 - w2;
     }


### PR DESCRIPTION
This fixes inline-style CSP warnings.

Changing the structure of the code seemed to cause issues when the inner styles height and width was specified; however removing it seems to cause no issues that I can replicate.
