### PR TITLE
IE10+ scrollbars won't scroll completely unless scrollbar hidden

### DIFF
--- a/antiscroll.css
+++ b/antiscroll.css
@@ -42,6 +42,7 @@
 
 .antiscroll-inner {
   overflow: scroll;
+  -ms-overflow-style: none;
 }
 
 /** A bug in Chrome 25 on Lion requires each selector to have their own


### PR DESCRIPTION
`-ms-overflow-style: none` - Indicates the element does not display scrollbars or panning indicators, even when its content overflows.

Without this, anti scroll can't be scrolled where the scrollbar usually is, thereby cutting off the content.
