### PR TITLE
Antiscroll not cleaning up correctly after itself

### DIFF
--- a/antiscroll.js
+++ b/antiscroll.js
@@ -6,8 +6,10 @@
 
   $.fn.antiscroll = function (options) {
     return this.each(function () {
-      if ($(this).data('antiscroll')) {
-        $(this).data('antiscroll').destroy();
+      var antiscroll = $(this).data('antiscroll');
+      if (antiscroll) {
+        antiscroll.inner.attr('style', '');
+        antiscroll.destroy();
       }
 
       $(this).data('antiscroll', new $.Antiscroll(this, options));


### PR DESCRIPTION
On line 43, Antiscroll set's the width and height of `.antiscroll-inner` element and on line 58 it uses those dimensions to determine if scrollbars needs added. Whenever you call `$(selector).antiscroll()` the plugin destroys the Antiscroll instance but doesn't reset the dimensions of `.antiscroll-inner` element.

This creates very subtle problems with resizing tables. 

The solution is to do proper cleanup. 

Note: this effects how Ember Table rebuilds the antiscroll because you don't need to call `.rebuild` you can just reinstantiate Antiscroll. I'll submit a PR for that as well.
